### PR TITLE
remove the base path from the build

### DIFF
--- a/.github/workflows/deploy-github-pages.yaml
+++ b/.github/workflows/deploy-github-pages.yaml
@@ -36,7 +36,7 @@ jobs:
         run: (npm run lint)
       - name: Build Project
         working-directory: astro
-        run: (npm run build -- --site https://code4community-lexington.github.io --base organization.website)
+        run: (npm run build -- --site https://code4community-lexington.github.io)
       - name: Upload Artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
I think that this base path may not be needed. It could be our css issue. This is a test. Try merging and see if it fixes it. This is trying to address #47 