### PR TITLE
chore: add github url and icon to social links

### DIFF
--- a/astro/src/components/SocialLinks.astro
+++ b/astro/src/components/SocialLinks.astro
@@ -1,12 +1,15 @@
 ---
 import { Icon } from "astro-icon/components";
-const { secondaryColor, socials } = Astro.props;
+const { secondaryColor, socials, githubUrl } = Astro.props;
 ---
 
 <div
   class="flex gap-4 py-4 px-10 rounded-full"
   style={`background-color: ${secondaryColor}`}
 >
+  <a href={githubUrl}>
+    <Icon name="github" size="24" />
+  </a>
   {
     // This will render the social icons. It's important that the icon you intend to use follows the naming convention of the astro-icon package. The icons are intend
     // to be stored in the src/icons folder by convention. Make sure this matches the icon name in the contributors.json file.

--- a/astro/src/pages/contributors.astro
+++ b/astro/src/pages/contributors.astro
@@ -50,6 +50,7 @@ const colors = tailwind.theme.extend.colors;
               <SocialLinks
                 secondaryColor={secondaryColor}
                 socials={contributor.socials}
+                githubUrl={contributor.github_url}
               />
             </div>
           );


### PR DESCRIPTION
I noticed that I had completely left off the GitHub URL. After discussing it with Neal, we decided to add it as a 4th icon. It will always default to the first icon as our data structure leaves it out of the social links array. We are also implicitly making GitHub URL a required data field now, which, in my opinion, is ok, but I just wanted to inform the team.